### PR TITLE
Fix CORS errors

### DIFF
--- a/directus/.env
+++ b/directus/.env
@@ -3,6 +3,8 @@
 
 PORT=8055
 PUBLIC_URL="http://localhost:8055"
+CORS_ENABLED=true
+CORS_ORIGIN=true
 
 ####################################################################################################
 ## Database


### PR DESCRIPTION
The Directus example was bumped to `9.7.0` in #90, but `9.7.0` in particular started to make CORS being an opt-in config instead, thus causing potential issues such as reported in #105.

This PRs opts to enable CORS and turn `CORS_ORIGIN` to true, rather than specifying exact origins, since not all examples uses the same port.