### PR TITLE
Fix components imports for Gatsby Example

### DIFF
--- a/gatsby/src/components/footer.jsx
+++ b/gatsby/src/components/footer.jsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import IconGithub from "./icons/Github";
-import IconLinkedin from "./icons/Linkedin";
-import IconTwitter from "./icons/Twitter";
-import IconYoutube from "./icons/Youtube";
+import IconGithub from "./icons/github";
+import IconLinkedin from "./icons/linkedin";
+import IconTwitter from "./icons/twitter";
+import IconYoutube from "./icons/youtube";
 
 export default function Footer() {
   return (

--- a/gatsby/src/components/header.jsx
+++ b/gatsby/src/components/header.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import IconMonospace from "./icons/Monospace";
+import IconMonospace from "./icons/monospace";
 
 export default function Header() {
   return (

--- a/gatsby/src/components/moreArticles.jsx
+++ b/gatsby/src/components/moreArticles.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Article from "./Article";
+import Article from "./article";
 
 export default function MoreArticles({ articles }) {
   return (

--- a/gatsby/src/layouts/default.jsx
+++ b/gatsby/src/layouts/default.jsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { Helmet } from "react-helmet";
-import Notice from "../components/Notice";
-import Header from "../components/Header";
-import Info from "../components/Info";
-import Footer from "../components/Footer";
+import Notice from "../components/notice";
+import Header from "../components/header";
+import Info from "../components/info";
+import Footer from "../components/footer";
 
 export default function DefaultLayout({ children }) {
   return (

--- a/gatsby/src/pages/index.jsx
+++ b/gatsby/src/pages/index.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import DefaultLayout from "../layouts/default";
-import Hero from "../components/Hero";
-import Article from "../components/Article";
+import Hero from "../components/hero";
+import Article from "../components/article";
 import { formatRelativeTime } from "../../../shared/utils/format-relative-time";
 import { graphql } from "gatsby";
 

--- a/gatsby/src/templates/article.jsx
+++ b/gatsby/src/templates/article.jsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import { Link } from "gatsby";
 import DefaultLayout from "../layouts/default";
-import MoreArticles from "../components/MoreArticles";
-import IconBack from "../components/icons/Back";
-import IconLink from "../components/icons/Link";
-import IconGithub from "../components/icons/Github";
-import IconYoutube from "../components/icons/Youtube";
-import IconLinkedin from "../components/icons/Linkedin";
-import IconTwitter from "../components/icons/Twitter";
+import MoreArticles from "../components/moreArticles";
+import IconBack from "../components/icons/back";
+import IconLink from "../components/icons/link";
+import IconGithub from "../components/icons/github";
+import IconYoutube from "../components/icons/youtube";
+import IconLinkedin from "../components/icons/linkedin";
+import IconTwitter from "../components/icons/twitter";
 import { getAssetURL } from "../utils/get-asset-url";
 
 export default function ArticleTemplate({ pageContext }) {


### PR DESCRIPTION
I didn't check history to look what was the idea, but this is quick fix
for non-working import caused by mismatched letter casing in components
names.