### PR TITLE
Fix existing token check

### DIFF
--- a/eleventy/.eleventy.js
+++ b/eleventy/.eleventy.js
@@ -5,7 +5,7 @@ const { Directus } = require("@directus/sdk");
 const getDirectusClient = async () => {
   const directus = new Directus(process.env.DIRECTUS_URL);
 
-  if (directus.auth.token) return directus;
+  if (await directus.auth.token) return directus;
 
   if (process.env.DIRECTUS_EMAIL && process.env.DIRECTUS_PASSWORD) {
     await directus.auth.login({


### PR DESCRIPTION
Without `await` the check always yields true, thus effectively preventing the following code from execution. Effectively, SDK is bound to use anonymous auth.